### PR TITLE
merge Profile contract to RecoveryStory contract

### DIFF
--- a/contract/contracts/Profile.sol
+++ b/contract/contracts/Profile.sol
@@ -14,7 +14,7 @@ contract Profile {
 
     uint256 userId = 1;
 
-    mapping(address=>uint256) addressTouserId; // アドレスとユーザーIDの紐付け
+    mapping(address=>uint256) public addressTouserId; // アドレスとユーザーIDの紐付け
 
     function createUserProfile(string memory _name, string memory _avatar) external {
         require(addressTouserId[msg.sender] == 0, "An account already exists.");
@@ -36,4 +36,11 @@ contract Profile {
         uint256 _userId = addressTouserId[msg.sender] - 1;
         return (userProfile[_userId].name, userProfile[_userId].avatar, userProfile[_userId].walletAddress);
     }
+
+    function getAuthor(address _authorAddress) public view returns(string memory) {
+        require(addressTouserId[_authorAddress] > 0, "You have not yet registered a profile.");
+        uint256 _userId = addressTouserId[_authorAddress] - 1;
+        return (userProfile[_userId].name);
+    }
+
 }

--- a/contract/contracts/RecoveryStory.sol
+++ b/contract/contracts/RecoveryStory.sol
@@ -3,6 +3,7 @@
 
 pragma solidity ^0.8.9;
 
+
 contract RecoveryStory {
     struct Story {
         string storyTitle; //タイトル
@@ -16,12 +17,51 @@ contract RecoveryStory {
         address authorAddress;  //著者のアドレス
     }
 
+    struct UserProfile {
+        string name; // username
+        string avatar; // user avator -> あらかじめ数枚Contract側で用意する？
+        address walletAddress;
+    }
+
+    UserProfile[] public userProfile;
+
+    uint256 userId = 1;
+
+    mapping(address=>uint256) addressTouserId; // アドレスとユーザーIDの紐付け
+
     Story[] public story;
 
     uint public storyIdCounter = 1;
 
     mapping(string=>address) titleToAddress; // 作品タイトルと所有者アドレスの紐づけ
     mapping(string=>uint) titleToStoryId; // 作品タイトルと作品IDの紐づけ
+
+    function createUserProfile(string memory _name, string memory _avatar) external {
+        require(addressTouserId[msg.sender] == 0, "An account already exists.");
+        UserProfile memory _newUserProfile = UserProfile(_name, _avatar, msg.sender);
+        userProfile.push(_newUserProfile);
+        addressTouserId[msg.sender] = userId;
+        userId ++;
+    }
+
+    function editUserProfile(string memory _name, string memory _avatar) external {
+        require(addressTouserId[msg.sender] > 0, "You have not yet registered a profile.");
+        uint256 _userId = addressTouserId[msg.sender] - 1;
+        userProfile[_userId].name = _name;
+        userProfile[_userId].avatar = _avatar;
+    }
+
+    function getUserProfile() external view returns(string memory, string memory, address){
+        require(addressTouserId[msg.sender] > 0, "You have not yet registered a profile.");
+        uint256 _userId = addressTouserId[msg.sender] - 1;
+        return (userProfile[_userId].name, userProfile[_userId].avatar, userProfile[_userId].walletAddress);
+    }
+
+    function getAuthor(address _authorAddress) public view returns(string memory) {
+        require(addressTouserId[_authorAddress] > 0, "You have not yet registered a profile.");
+        uint256 _userId = addressTouserId[_authorAddress] - 1;
+        return (userProfile[_userId].name);
+    }
 
     function createStory(
         string memory _storyTitle,
@@ -68,16 +108,30 @@ contract RecoveryStory {
         titleToAddress[_storyTitle] = msg.sender;
     }
 
-    function getNft(string memory _storyTitle) external view returns (
+    function getStory(string memory _storyTitle) external view returns (
         string memory,
         string[] memory,
+        string memory,
         string memory,
         string memory,
         uint, uint, uint, uint, address
       ) {
         uint256 _storyId = titleToStoryId[_storyTitle] - 1;
-        return (story[_storyId].storyTitle, story[_storyId].tags, story[_storyId].storyBody,
-            story[_storyId].icatchSvg, story[_storyId].createDate, story[_storyId].updateDate,
-            story[_storyId].numLike, story[_storyId].itemId, story[_storyId].authorAddress);
+        string memory storyAuthor = getAuthor(story[_storyId].authorAddress);
+        return (
+            story[_storyId].storyTitle,
+            story[_storyId].tags,
+            story[_storyId].storyBody,
+            story[_storyId].icatchSvg,
+            storyAuthor,
+            story[_storyId].createDate,
+            story[_storyId].updateDate,
+            story[_storyId].numLike,
+            story[_storyId].itemId,
+            story[_storyId].authorAddress
+        );
     }
 }
+
+// "cardene", "cardene avatar"
+// "cardene",["A","B"],"cardene story","cardene svg"

--- a/contract/contracts/Story.sol
+++ b/contract/contracts/Story.sol
@@ -16,7 +16,7 @@ import { Base64 } from "./libraries/Base64.sol";
 
 // インポートした OpenZeppelin のコントラクトを継承。
 // 継承したコントラクトのメソッドにアクセスできるようになる。
-contract RecoveryStory is ERC721URIStorage {
+contract Story is ERC721URIStorage {
 
   // OpenZeppelin が tokenIds を簡単に追跡するために提供するライブラリを呼び出しています
   using Counters for Counters.Counter;


### PR DESCRIPTION
`Profile.sol`のstructやmappingのデータを`RecoveryStory.sol`で使用することができなかったため、`RecoveryStory.sol`に統合しました。